### PR TITLE
Added retrieving DOCSIS 3.1 stats in upstream

### DIFF
--- a/fritzDocsis.go
+++ b/fritzDocsis.go
@@ -57,6 +57,13 @@ type docInfo struct {
 		} `json:"channelDs"`
 		Oem       string `json:"oem"`
 		ChannelUs struct {
+			Docsis31 []struct {
+				PowerLevel string `json:"powerLevel"`
+				Type       string `json:"type"`
+				Channel    int    `json:"channel"`
+				ChannelID  int    `json:"channelID"`
+				Frequency  string `json:"frequency"`
+			} `json:"docsis31"`
 			Docsis30 []struct {
 				PowerLevel string `json:"powerLevel"`
 				Type       string `json:"type"`
@@ -163,6 +170,19 @@ func setMetrics(data *docInfo) {
 			"direction":     "upstream",
 			"frequency":     channel.Frequency,
 			"docsisVersion": "3.0",
+		}
+		powerLevelData, _ := strconv.ParseFloat(channel.PowerLevel, 64)
+		powerLevel.With(labels).Set(powerLevelData)
+		connectionTypeData, _ := strconv.ParseFloat(strings.TrimSuffix(channel.Type, "QAM"), 64)
+		connectionType.With(labels).Set(connectionTypeData)
+	}
+	for _, channel := range data.Data.ChannelUs.Docsis31 {
+		labels := prometheus.Labels{
+			"channel":       strconv.Itoa(channel.Channel),
+			"channelID":     strconv.Itoa(channel.ChannelID),
+			"direction":     "upstream",
+			"frequency":     channel.Frequency,
+			"docsisVersion": "3.1",
 		}
 		powerLevelData, _ := strconv.ParseFloat(channel.PowerLevel, 64)
 		powerLevel.With(labels).Set(powerLevelData)


### PR DESCRIPTION
Hi Chris,

Vodafone hat begonnen, DOCSIS 3.1 auch im Upstream zu verwenden. Ich habe den DOCSIS 3.1 Code aus downstream übernommen dass DOCSIS 3.1 Parameter auch im Upstream aus der Fritzbox übernommen werden.

Beste Grüße aus Frankfurt/Main
Andreas